### PR TITLE
Add a 'clear' command to ease resetting db while developing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+*.sqlite3
 media/posters/**
 media/films/**
 media/subtitles/**
+
+__pycache__/
+venv
+

--- a/application/management/commands/clear.py
+++ b/application/management/commands/clear.py
@@ -12,14 +12,13 @@ class Command(BaseCommand):
     help = "Clear all Cinema data (for testing purpose)"
 
     def handle(self, *args, **options):
-        all_models = list(chain(MovieDirectory.objects.all(),
-            Movie.objects.all(), NewMovieNotification.objects.all(), 
-            MovieRequest.objects.all(), WatchlistItem.objects.all(),
-            Subtitle.objects.all()))
+        all_models = [Movie, MovieDirectory, MovieRequest, 
+                NewMovieNotification, Subtitle, WatchlistItem]
 
-        print(f"Delete {len(all_models)} models")
         for model in all_models:
-            model.delete()
+            objects_to_delete = model.objects.all()
+            print(f" Delete {len(objects_to_delete)} {model.__name__}")
+            objects_to_delete.delete()
 
         for folder in ['films', 'posters', 'subtitles']:
             self.delete_folder(folder)

--- a/application/management/commands/clear.py
+++ b/application/management/commands/clear.py
@@ -5,7 +5,7 @@ import shutil
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from application.models import (MovieDirectory, Movie, MovieRequest, 
-                NewMovieNotification, WatchlistItem, Subtitle, Profile)
+                NewMovieNotification, WatchlistItem, Subtitle)
 
 
 class Command(BaseCommand):
@@ -15,7 +15,7 @@ class Command(BaseCommand):
         all_models = list(chain(MovieDirectory.objects.all(),
             Movie.objects.all(), NewMovieNotification.objects.all(), 
             MovieRequest.objects.all(), WatchlistItem.objects.all(),
-            Subtitle.objects.all(), Profile.objects.all()))
+            Subtitle.objects.all()))
 
         print(f"Delete {len(all_models)} models")
         for model in all_models:
@@ -34,9 +34,10 @@ class Command(BaseCommand):
             try:
                 if os.path.isfile(path) and not the_file.startswith('.'):
                     os.unlink(path)
-                    print("Delete file " + path)
+                    print(f"Delete file {path}")
                 elif os.path.isdir(path):
                     shutil.rmtree(path)
-                    print("Delete directory " + path)
+                    print(f"Delete directory {path}")
             except Exception as e:
-                print(e)
+                print(f"Exception while deleting {path}: {e}")
+                break

--- a/application/management/commands/clear.py
+++ b/application/management/commands/clear.py
@@ -1,0 +1,42 @@
+from itertools import chain
+import os
+import shutil
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from application.models import (MovieDirectory, Movie, MovieRequest, 
+                NewMovieNotification, WatchlistItem, Subtitle, Profile)
+
+
+class Command(BaseCommand):
+    help = "Clear all Cinema data (for testing purpose)"
+
+    def handle(self, *args, **options):
+        all_models = list(chain(MovieDirectory.objects.all(),
+            Movie.objects.all(), NewMovieNotification.objects.all(), 
+            MovieRequest.objects.all(), WatchlistItem.objects.all(),
+            Subtitle.objects.all(), Profile.objects.all()))
+
+        print(f"Delete {len(all_models)} models")
+        for model in all_models:
+            model.delete()
+
+        for folder in ['films', 'posters', 'subtitles']:
+            self.delete_folder(folder)
+
+
+    def delete_folder(self, folder_name):
+        print(f"Delete {folder_name} directory...")
+
+        folder = os.path.join(settings.MEDIA_ROOT, folder_name)
+        for the_file in os.listdir(folder):
+            path = os.path.join(folder, the_file)
+            try:
+                if os.path.isfile(path) and not the_file.startswith('.'):
+                    os.unlink(path)
+                    print("Delete file " + path)
+                elif os.path.isdir(path):
+                    shutil.rmtree(path)
+                    print("Delete directory " + path)
+            except Exception as e:
+                print(e)


### PR DESCRIPTION
This is a simple Django 'clear' command to erase the whole Cinema data (db rows, media files) without having to delete the db file and rerun migrations.