### PR TITLE
Update django to 4.1+

### DIFF
--- a/application/urls.py
+++ b/application/urls.py
@@ -1,18 +1,18 @@
-from django.conf.urls import url
+from django.urls import re_path
 from . import views
 from .models import MoviesFeed
 
 urlpatterns = [
-    url('^$', views.index, name='index'),
-    url('^watch/(?P<mid>[0-9]+)$', views.watch, name="watch"),
-    url('^profile$', views.profile, name="profile"),
-    url('^random$', views.random_movie, name="random"),
-    url('^rss$', MoviesFeed(), name="rss"),
-    url('^regen_key$', views.regen_key, name="regen_key"),
-    url('^new_movies$', views.new_movies, name='new_movies'),
-    url('^watchlist/add$', views.watchlist_add, name='watchlist_add'),
-    url('^watchlist/remove$', views.watchlist_remove, name='watchlist_remove'),
-    url('^watchlist/list$', views.watchlist_list, name='watchlist_list'),
-    url('^request$', views.movie_request, name='movie_request'),
-    url('^request/delete/(?P<pk>[0-9]+)$', views.delete_movie_request, name='delete_movie_request'),
+    re_path('^$', views.index, name='index'),
+    re_path('^watch/(?P<mid>[0-9]+)$', views.watch, name="watch"),
+    re_path('^profile$', views.profile, name="profile"),
+    re_path('^random$', views.random_movie, name="random"),
+    re_path('^rss$', MoviesFeed(), name="rss"),
+    re_path('^regen_key$', views.regen_key, name="regen_key"),
+    re_path('^new_movies$', views.new_movies, name='new_movies'),
+    re_path('^watchlist/add$', views.watchlist_add, name='watchlist_add'),
+    re_path('^watchlist/remove$', views.watchlist_remove, name='watchlist_remove'),
+    re_path('^watchlist/list$', views.watchlist_list, name='watchlist_list'),
+    re_path('^request$', views.movie_request, name='movie_request'),
+    re_path('^request/delete/(?P<pk>[0-9]+)$', views.delete_movie_request, name='delete_movie_request'),
 ]

--- a/cinema/settings.py
+++ b/cinema/settings.py
@@ -84,6 +84,7 @@ DATABASES = {
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
+DEFAULT_AUTO_FIELD='django.db.models.AutoField'
 
 
 # Password validation

--- a/cinema/urls.py
+++ b/cinema/urls.py
@@ -14,17 +14,17 @@ Including another URLconf
     2. Import the include() function: from django.conf.urls import url, include
     3. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import url, include
+from django.urls import re_path, include
 from django.conf import settings
 from django.conf.urls.static import  static
 from django.contrib.auth import views as auth_views
 from django.contrib import admin
 
 urlpatterns = [
-    url('login/', auth_views.LoginView.as_view(template_name='login.html', extra_context={'login_required': settings.LOGIN_REQUIRED}), name='login'),
-    url('logout/', auth_views.LogoutView.as_view(next_page='/login/'), name='logout'),
-    url('^', include('application.urls')),
-    url('^admin/', admin.site.urls),
+    re_path('login/', auth_views.LoginView.as_view(template_name='login.html', extra_context={'login_required': settings.LOGIN_REQUIRED}), name='login'),
+    re_path('logout/', auth_views.LogoutView.as_view(next_page='/login/'), name='logout'),
+    re_path('^', include('application.urls')),
+    re_path('^admin/', admin.site.urls),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ Pygments>=2.1.3
 python-dateutil>=2.7.5
 requests>=2.20.0
 six>=1.12.0
-word2number>1.1
+word2number>=1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.5.4
 babelfish>=0.5.5
-Django>=2.1
+Django>=4.1
 guessit>=3.0.3
 Pillow>=5.4.1
 Pygments>=2.1.3


### PR DESCRIPTION
    - Change `django.conf.urls.url` to `django.urls.re_path`. `url` was
    deprecated during the django 2.X dev cycle as can be seen here:
    https://docs.djangoproject.com/en/2.2/ref/urls/#django.conf.urls.url

    - Add a `DEFAULT_AUTO_FIELD` setting, that's required since django 3.X,
      see https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys

    - Fix a ton of async related things, django doesn't want us to call the
      ORM from an async function without any wrapper around said calls.